### PR TITLE
Use rest_framework's exception_handler in DEBUG

### DIFF
--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -150,14 +150,8 @@ def exception_reporter(exc: BaseException, context: Optional[Dict] = None) -> No
 def exception_handler(
     exc: BaseException, context: Optional[Dict] = None
 ) -> Optional[Response]:
-    # Handle Django base exceptions
-    if (
-        getattr(settings, "DEBUG", False)
-        and not api_settings.ENABLE_IN_DEBUG
-        and not isinstance(exc, exceptions.APIException)
-    ):
-        # By default don't handle errors in DEBUG mode
-        return None
+
+    # Special handling for Django base exceptions first
     if isinstance(exc, Http404):
         exc = exceptions.NotFound()
     elif isinstance(exc, PermissionDenied):
@@ -167,6 +161,15 @@ def exception_handler(
             "",
             protected_objects=exc.protected_objects,
         )
+
+    if (
+        getattr(settings, "DEBUG", False)
+        and not api_settings.ENABLE_IN_DEBUG
+        and not isinstance(exc, exceptions.APIException)
+    ):
+        # By default don't handle non-DRF errors in DEBUG mode, i.e. Django will treat
+        # unhandled exceptions regularly (very evident yellow error page)
+        return None
 
     exception_code, exception_key = _get_main_exception_and_code(exc)
 

--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 from rest_framework import exceptions, status
 from rest_framework.response import Response
+from rest_framework.views import set_rollback
 
 from .exceptions import ProtectedObjectException
 from .settings import api_settings
@@ -174,6 +175,8 @@ def exception_handler(
     exception_code, exception_key = _get_main_exception_and_code(exc)
 
     api_settings.EXCEPTION_REPORTING(exc, context)
+
+    set_rollback()
 
     return Response(
         dict(

--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -151,7 +151,11 @@ def exception_handler(
     exc: BaseException, context: Optional[Dict] = None
 ) -> Optional[Response]:
     # Handle Django base exceptions
-    if getattr(settings, "DEBUG", False) and not api_settings.ENABLE_IN_DEBUG:
+    if (
+        getattr(settings, "DEBUG", False)
+        and not api_settings.ENABLE_IN_DEBUG
+        and not isinstance(exc, exceptions.APIException)
+    ):
         # By default don't handle errors in DEBUG mode
         return None
     if isinstance(exc, Http404):

--- a/exceptions_hog/settings.py
+++ b/exceptions_hog/settings.py
@@ -7,9 +7,10 @@ USER_SETTINGS: Dict = getattr(settings, "EXCEPTIONS_HOG", None)
 
 DEFAULTS: Dict = {
     "EXCEPTION_REPORTING": "exceptions_hog.handler.exception_reporter",
+    "ENABLE_IN_DEBUG": False,
 }
 
 # List of settings that may be in string import notation.
-IMPORT_STRINGS = ("EXCEPTION_REPORTING",)
+IMPORT_STRINGS = ("EXCEPTION_REPORTING", "ENABLE_IN_DEBUG")
 
 api_settings: APISettings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)

--- a/exceptions_hog/settings.py
+++ b/exceptions_hog/settings.py
@@ -11,6 +11,7 @@ DEFAULTS: Dict = {
 }
 
 # List of settings that may be in string import notation.
-IMPORT_STRINGS = ("EXCEPTION_REPORTING", "ENABLE_IN_DEBUG")
+# e.g. `exceptions_hog.exception_handler`
+IMPORT_STRINGS = ("EXCEPTION_REPORTING",)
 
 api_settings: APISettings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ test=pytest
 
 [isort]
 profile=black
-line_length=89
+line_length=120
 
 [flake8]
-max-line-length = 89
+max-line-length = 120
 
 [mypy]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ test=pytest
 
 [isort]
 profile=black
-line_length=120
+line_length=89
 
 [flake8]
-max-line-length = 120
+max-line-length = 89
 
 [mypy]
 ignore_missing_imports = true

--- a/test_project/test_app/views.py
+++ b/test_project/test_app/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from rest_framework.exceptions import APIException
 from rest_framework.generics import GenericAPIView
 from rest_framework.viewsets import ModelViewSet
@@ -36,5 +37,11 @@ class ExceptionView(GenericAPIView):
             sample_dict["b"]
         elif exception_type == "api_error":
             raise APIException()
+        elif exception_type == "atomic_transaction":
+            Hedgehog.objects.create(name="One")
+
+            with transaction.atomic():
+                Hedgehog.objects.create(name="Two")
+                raise APIException()
 
         raise Exception("Shouldn't be included in the response.")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,7 +80,13 @@ class TestAPI:
             "attr": "name",
         }
 
-    def test_unhandled_server_error(self, test_client, res_server_error) -> None:
+    def test_unhandled_server_error(
+        self,
+        test_client,
+        res_server_error,
+        settings,
+        monkeypatch,
+    ) -> None:
         """
         Tests generic unhandled Python exceptions. Note we assert that a generic
         error message is returned in these cases to avoid leaking sensitive information.
@@ -106,7 +112,9 @@ class TestAPI:
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.data == res_server_error
 
-        # Exception
+        # Exception (even on debug but with ENABLE_IN_DEBUG)
+        settings.DEBUG = True
+        monkeypatch.setattr(api_settings, "ENABLE_IN_DEBUG", True)
         response = test_client.post("/exception")
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.data == res_server_error
@@ -130,3 +138,16 @@ class TestAPI:
         # Error response behavior is the same
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.data == res_server_error
+
+    def test_yield_non_drf_exceptions_to_django_in_debug(self, test_client, settings):
+        settings.DEBUG = True
+
+        # Key Error
+        with pytest.raises(KeyError) as e:
+            test_client.post("/exception", {"type": "key_error"})
+        assert e.typename == "KeyError"
+
+        # Assertion Error
+        with pytest.raises(AssertionError) as e:
+            test_client.post("/exception", {"type": "assertion_error"})
+        assert e.typename == "AssertionError"

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -154,7 +154,7 @@ def test_type_error(res_server_error) -> None:
 
 def test_throttled_exception_debug(settings) -> None:
     settings.DEBUG = True
-    # Same as normal since APIException
+    # Same as normal since APIException instance
     response = exception_handler(exceptions.Throttled(62))
     assert response is not None
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
@@ -166,7 +166,23 @@ def test_throttled_exception_debug(settings) -> None:
     }
 
 
+def test_not_found_exception_debug(settings, res_not_found) -> None:
+    settings.DEBUG = True
+    # Same as normal, since APIException instance
+    response = exception_handler(exceptions.NotFound())
+    assert response is not None
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.data == res_not_found
+
+    # Test Django base exception too
+    # Not handled, since not APIException instance
+    # (Django errors only inherit from the Python Exception)
+    response = exception_handler(Http404())
+    assert response is None
+
+
 def test_type_error_debug(settings) -> None:
     settings.DEBUG = True
+    # Not handled, since not APIException instance
     response = exception_handler(TypeError())
     assert response is None

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from rest_framework import exceptions, status
 
 from exceptions_hog.handler import exception_handler
+from exceptions_hog.settings import api_settings
 
 # DRF exceptions
 
@@ -186,3 +187,13 @@ def test_type_error_debug(settings) -> None:
     # Not handled, since not APIException instance
     response = exception_handler(TypeError())
     assert response is None
+
+
+def test_type_error_enabled_in_debug(res_server_error, settings, monkeypatch) -> None:
+    settings.DEBUG = True
+    monkeypatch.setattr(api_settings, "ENABLE_IN_DEBUG", True)
+    # Handled, since ENABLE_IN_DEBUG is True
+    response = exception_handler(TypeError())
+    assert response is not None
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.data == res_server_error

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -152,7 +152,7 @@ def test_type_error(res_server_error) -> None:
 # Non-APIException handling disabled in DEBUG mode
 
 
-def test_throttled_exception() -> None:
+def test_throttled_exception_debug(settings) -> None:
     settings.DEBUG = True
     # Same as normal since APIException
     response = exception_handler(exceptions.Throttled(62))
@@ -165,12 +165,8 @@ def test_throttled_exception() -> None:
         "attr": None,
     }
 
-def test_not_found_exception_debug(settings) -> None:
-    settings.DEBUG = True
-    # Return None since not APIException
-    response = exception_handler(exceptions.NotFound())
-    assert response is None
 
-    # Test Django base exception too
-    response = exception_handler(Http404())
+def test_type_error_debug(settings) -> None:
+    settings.DEBUG = True
+    response = exception_handler(TypeError())
     assert response is None

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -5,10 +5,12 @@ from rest_framework import exceptions, status
 
 from exceptions_hog.handler import exception_handler
 
-
 # DRF exceptions
+
+
 def test_not_acceptable_exception() -> None:
     response = exception_handler(exceptions.NotAcceptable())
+    assert response is not None
     assert response.status_code == status.HTTP_406_NOT_ACCEPTABLE
     assert response.data == {
         "type": "invalid_request",
@@ -20,6 +22,7 @@ def test_not_acceptable_exception() -> None:
 
 def test_unsupported_media_type_exception() -> None:
     response = exception_handler(exceptions.UnsupportedMediaType("application/xml"))
+    assert response is not None
     assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
     assert response.data == {
         "type": "invalid_request",
@@ -31,6 +34,7 @@ def test_unsupported_media_type_exception() -> None:
 
 def test_throttled_exception() -> None:
     response = exception_handler(exceptions.Throttled(62))
+    assert response is not None
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
     assert response.data == {
         "type": "throttled_error",
@@ -41,11 +45,11 @@ def test_throttled_exception() -> None:
 
 
 def test_validation_error() -> None:
-
     # Default code
     response = exception_handler(
         exceptions.ValidationError("I did not like your input.")
     )
+    assert response is not None
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data == {
         "type": "validation_error",
@@ -58,6 +62,7 @@ def test_validation_error() -> None:
     response = exception_handler(
         exceptions.ValidationError("I did not like your input.", code="ugly_input")
     )
+    assert response is not None
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data == {
         "type": "validation_error",
@@ -71,34 +76,36 @@ def test_validation_error() -> None:
 
 
 def test_not_found_exception(res_not_found) -> None:
-
     response = exception_handler(exceptions.NotFound())
+    assert response is not None
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.data == res_not_found
 
     # Test Django base exception too
     response = exception_handler(Http404())
+    assert response is not None
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.data == res_not_found
 
 
 def test_permission_denied_exception(res_permission_denied) -> None:
-
     response = exception_handler(exceptions.PermissionDenied())
+    assert response is not None
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data == res_permission_denied
 
     # Test Django base exception too
     response = exception_handler(PermissionDenied())
+    assert response is not None
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data == res_permission_denied
 
 
 def test_protected_error() -> None:
-
     response = exception_handler(
         ProtectedError("Resource 'Hedgehog' has dependencies.", protected_objects=[1])
     )
+    assert response is not None
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.data == {
         "type": "invalid_request",
@@ -112,26 +119,58 @@ def test_protected_error() -> None:
 # Python exceptions
 
 
-def test_python_exceptions(res_server_error) -> None:
-
-    # NotImplementedError
+def test_not_implemented_error(res_server_error) -> None:
     response = exception_handler(
         NotImplementedError("This function is not implemented")
     )
+    assert response is not None
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.data == res_server_error
 
-    # AttributeError
+
+def test_attribute_error(res_server_error) -> None:
     response = exception_handler(AttributeError())
+    assert response is not None
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.data == res_server_error
 
-    # ImportError
+
+def test_import_error(res_server_error) -> None:
     response = exception_handler(ImportError())
+    assert response is not None
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.data == res_server_error
 
-    # TypeError
+
+def test_type_error(res_server_error) -> None:
     response = exception_handler(TypeError())
+    assert response is not None
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.data == res_server_error
+
+
+# Non-APIException handling disabled in DEBUG mode
+
+
+def test_throttled_exception() -> None:
+    settings.DEBUG = True
+    # Same as normal since APIException
+    response = exception_handler(exceptions.Throttled(62))
+    assert response is not None
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert response.data == {
+        "type": "throttled_error",
+        "code": "throttled",
+        "detail": "Request was throttled. Expected available in 62 seconds.",
+        "attr": None,
+    }
+
+def test_not_found_exception_debug(settings) -> None:
+    settings.DEBUG = True
+    # Return None since not APIException
+    response = exception_handler(exceptions.NotFound())
+    assert response is None
+
+    # Test Django base exception too
+    response = exception_handler(Http404())
+    assert response is None


### PR DESCRIPTION
This should expose `rest_framework`'s `exception_handler` function instead of `exceptions_hog`'s in DEBUG mode. Disableable with setting `EXCEPTIONS_HOG` subsetting `ENABLE_IN_DEBUG`.