### PR TITLE
Default arguments should not be mutable objects

### DIFF
--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -73,7 +73,7 @@ def _get_error_type(exc) -> Union[str, ErrorTypes]:
 
 def _normalize_exception_codes(
     exception_codes: Dict,
-    parent_key: List[str] = [],
+    parent_key: List[str] = None,
 ) -> List[Dict[str, Union[str, List[str]]]]:
     """
     Returns a normalized one-level dictionary of exception attributes and codes. Used to
@@ -90,6 +90,9 @@ def _normalize_exception_codes(
          }
      ]
     """
+    if parent_key is None:
+        parent_key = []
+
     items: List = []
     for key, exception_code in exception_codes.items():
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 Django==3.2.9
-black==21.11b1
+black==22.3.0
 flake8==3.8.*
 isort==5.5.*
 mypy==0.782


### PR DESCRIPTION
Do not use mutable objects as default arguments in Python