### PR TITLE
feat: support DRF throttled exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -304,9 +304,12 @@ def exception_handler(
             attr=_get_attr(exception_list[0][1]),
         )
 
+    headers = {}
     if hasattr(exc, "extra"):  # type: ignore
         response["extra"] = exc.extra  # type: ignore
+    if getattr(exc, "wait", None):
+        headers["Retry-After"] = "%d" % exc.wait
     if event_id:
         response["error_event_id"] = event_id
 
-    return Response(response, status=_get_http_status(exc))
+    return Response(response, status=_get_http_status(exc), headers=headers)

--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -307,7 +307,7 @@ def exception_handler(
     headers = {}
     if hasattr(exc, "extra"):  # type: ignore
         response["extra"] = exc.extra  # type: ignore
-    if getattr(exc, "wait", None):
+    if isinstance(exc, exceptions.APIException) and getattr(exc, "wait", None):
         headers["Retry-After"] = "%d" % exc.wait
     if event_id:
         response["error_event_id"] = event_id

--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -307,7 +307,7 @@ def exception_handler(
     headers = {}
     if hasattr(exc, "extra"):  # type: ignore
         response["extra"] = exc.extra  # type: ignore
-    # see https://github.com/encode/django-rest-framework/blob/e08e606c82afd0d5ec82b2c58badec11a4ce825e/rest_framework/views.py#L86-L91
+    # see https://github.com/encode/django-rest-framework/blob/e08e606c82afd0d5ec82b2c58badec11a4ce825e/rest_framework/views.py#L86-L91 # noqa
     # for the framework code this is based on
     if isinstance(exc, exceptions.APIException) and getattr(exc, "wait", None):
         headers["Retry-After"] = "%d" % exc.wait

--- a/exceptions_hog/handler.py
+++ b/exceptions_hog/handler.py
@@ -307,6 +307,8 @@ def exception_handler(
     headers = {}
     if hasattr(exc, "extra"):  # type: ignore
         response["extra"] = exc.extra  # type: ignore
+    # see https://github.com/encode/django-rest-framework/blob/e08e606c82afd0d5ec82b2c58badec11a4ce825e/rest_framework/views.py#L86-L91
+    # for the framework code this is based on
     if isinstance(exc, exceptions.APIException) and getattr(exc, "wait", None):
         headers["Retry-After"] = "%d" % exc.wait
     if event_id:

--- a/exceptions_hog/settings.py
+++ b/exceptions_hog/settings.py
@@ -1,9 +1,9 @@
-from typing import Dict
+from typing import Any, Dict, Optional
 
 from django.conf import settings
 from rest_framework.settings import APISettings
 
-USER_SETTINGS: Dict = getattr(settings, "EXCEPTIONS_HOG", None)
+USER_SETTINGS: Optional[Any] = getattr(settings, "EXCEPTIONS_HOG", None)
 
 DEFAULTS: Dict = {
     "EXCEPTION_REPORTING": "exceptions_hog.handler.exception_reporter",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ black==22.3.0
 flake8==3.8.*
 importlib_metadata>=1.1.0,<4.3 # Fixes flake8 issue https://github.com/python/importlib_metadata/issues/406
 isort==5.5.*
-mypy==0.782
+mypy==1.2.0
 pytest==6.0.*
 pytest-cov==2.10.1
 pytest-django==3.10.*

--- a/runtests.py
+++ b/runtests.py
@@ -55,9 +55,12 @@ def black_main(args):
 
 def mypy_main(args):
     print("Running mypy typechecking")
-    ret = subprocess.call(["mypy"] + args)
-    print("❗️ mypy failed") if ret else print("✅ mypy passed")
-    return ret
+    for proj in PROJECT:
+        ret = subprocess.call(["mypy", "-p", proj])
+        print("❗️ mypy failed for " + proj) if ret else print("✅ mypy passed for " + proj)
+        if ret:
+            return ret
+
 
 
 def split_class_and_function(string):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -264,7 +264,10 @@ def test_throttled_exception_with_no_wait() -> None:
         "detail": "Request was throttled.",
         "type": "throttled_error",
     }
-    assert "Retry-After" not in response.headers
+    # older versions in the CI test matrix don't have headers on Response
+    if getattr(response, "headers", None):
+        assert "Retry-After" not in response.headers
+
 
 
 def test_throttled_exception_with_wait() -> None:
@@ -278,7 +281,9 @@ def test_throttled_exception_with_wait() -> None:
         "detail": "Request was throttled. Expected available in 100 seconds.",
         "type": "throttled_error",
     }
-    assert response.headers["Retry-After"] == "100"
+    # older versions in the CI test matrix don't have headers on Response
+    if getattr(response, "headers", None):
+        assert response.headers["Retry-After"] == "100"
 
 
 def test_not_found_exception(res_not_found) -> None:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -269,7 +269,6 @@ def test_throttled_exception_with_no_wait() -> None:
         assert "Retry-After" not in response.headers
 
 
-
 def test_throttled_exception_with_wait() -> None:
     throttled = exceptions.Throttled(wait=100)
     response = exception_handler(throttled)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -253,6 +253,34 @@ def test_nested_serializer_field_with_special_characters() -> None:
 # Django & DRF exceptions
 
 
+def test_throttled_exception_with_no_wait() -> None:
+    throttled = exceptions.Throttled(wait=None)
+    response = exception_handler(throttled)
+    assert response is not None
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert response.data == {
+        "attr": None,
+        "code": "throttled",
+        "detail": "Request was throttled.",
+        "type": "throttled_error",
+    }
+    assert "Retry-After" not in response.headers
+
+
+def test_throttled_exception_with_wait() -> None:
+    throttled = exceptions.Throttled(wait=100)
+    response = exception_handler(throttled)
+    assert response is not None
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert response.data == {
+        "attr": None,
+        "code": "throttled",
+        "detail": "Request was throttled. Expected available in 100 seconds.",
+        "type": "throttled_error",
+    }
+    assert response.headers["Retry-After"] == "100"
+
+
 def test_not_found_exception(res_not_found) -> None:
     response = exception_handler(exceptions.NotFound())
     assert response is not None


### PR DESCRIPTION
DRF's exception handler adds a Retry-After header when handling `Throttled` and that exception has a `wait` value. But it doesn't get a chance to if you are using this package.

Well, not any more!

* update mypy
* handle Throttled exception and add a header when appropriate