### PR TITLE
fix(ci): sign the commits this workflow creates

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          token: ${{ secrets.POSTHOG_BOT_PAT }}
           fetch-depth: 0
 
       - name: Detect version bump type
@@ -56,9 +55,12 @@ jobs:
 
       - name: Create bump pull request
         id: create-pr
-        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.POSTHOG_BOT_PAT }}
+          # Commit through the GitHub API so the bump carries GitHub's signature,
+          # which the org-wide signed-commits ruleset requires. Signing only works
+          # with a bot-generated token, never a PAT, so this uses GITHUB_TOKEN.
+          sign-commits: true
           commit-message: Bump drf-exceptions-hog to ${{ steps.version.outputs.new }}
           branch: bump-${{ steps.version.outputs.new }}
           delete-branch: true


### PR DESCRIPTION
## Summary

Makes the workflow that commits in this repo produce **signed** commits.

Commits created with plain `git` are unsigned. PostHog is rolling the org-wide "Require signed commits" ruleset out to every repo, and this workflow would be rejected with `GH013` once it applies here. Routing the commit through the GitHub API instead means GitHub signs it with its own key, so it lands verified.

Found while inventorying which workflows across the org still create unsigned commits. `planetscale/ghcommit-action` is the pattern already in use in `posthog-js`, `posthog-roblox`, `brand`, `charts` and the SDK release fleet.

## Changes

Upgrades `create-pull-request` from v3.14.0 to v8.1.1 and sets `sign-commits: true`.

## Testing

Not run end to end. **Two pre-existing problems surfaced while doing this, neither introduced here.** The workflow referenced `secrets.POSTHOG_BOT_PAT`, which does not exist on this repo or in the org secrets it can read, so both the checkout and the PR step were running with an empty token. Signing only works with a bot-generated token and never with a PAT, so the fix drops the phantom secret and uses `GITHUB_TOKEN`. Consequence to weigh: a PR opened by `GITHUB_TOKEN` does not trigger `on: pull_request` runs, so `CI.yml` will not run on the bump PR (`release.yml` still fires, since a human performs the merge). Separately, the job still targets `ubuntu-20.04`, which GitHub has retired, so this workflow cannot currently start at all; that is left alone as out of scope.
