### PR TITLE
fix(ci): grant the bump workflow the write permissions it now needs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [closed]
 
+# The repo's default workflow permission is read-only, so GITHUB_TOKEN needs these
+# spelled out to push the bump branch and open its pull request.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   label-version-bump:
     name: Bump version based on PR label


### PR DESCRIPTION
## Summary

Follow-up to #44. That PR dropped `secrets.POSTHOG_BOT_PAT` (a secret that does not exist on this repo, so both the checkout and the PR step were running with an empty token) and switched to `GITHUB_TOKEN`, which is required for `sign-commits` to work — signing only happens with a bot-generated token, never a PAT.

What it missed: this repo's default workflow permission is `read`, and the workflow declares no `permissions:` block. With the PAT gone, `GITHUB_TOKEN` has no write access, so the next `bump patch|minor|major` merge would fail with a 403 when create-pull-request tries to push the branch and open the PR.

## Changes

- Add a workflow-level `permissions:` block granting `contents: write` and `pull-requests: write`

## Testing

Not run end to end — the workflow only fires when a PR carrying a `bump *` label is merged, and it has only ever been skipped in recent history. Confirmed via `repos/PostHog/drf-exceptions-hog/actions/permissions/workflow` that `default_workflow_permissions` is `read`, and that no `permissions:` key exists anywhere in the workflow.

## Two pre-existing problems this does not fix

Flagging rather than fixing, since both are out of scope and predate #44:

- The job targets `ubuntu-20.04`, a runner GitHub has retired, so it cannot start at all. Whoever owns this repo should bump it.
- A PR opened with `GITHUB_TOKEN` does not trigger `on: pull_request` workflows, so `CI.yml` will not run on the bump PR. `release.yml` still fires, because a human performs the merge. A GitHub App token would both sign and trigger CI, if that matters enough to set one up.
